### PR TITLE
[FEAT]: 회원 정보 불러오기 및 프로필 사진 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.auth0:jwks-rsa:0.20.0'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // TEST
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.member.domain.repository.MemberRepository;
 import samsamoo.ai_mockly.domain.member.dto.response.MemberInfoRes;
@@ -51,6 +52,24 @@ public class MemberService {
 
         Message message = Message.builder()
                 .message("닉네임이 수정되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
+
+    @Transactional
+    public  SuccessResponse<Message> modifyProfileImage(Long memberId, MultipartFile profileImage) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadCredentialsException("해당 아이디를 갖는 유저가 없습니다."));
+
+        String ImageUrl = profileImage.getOriginalFilename();
+
+        if(!profileImage.isEmpty()) {
+            member.updateProfileImage(ImageUrl);
+        }
+
+        Message message = Message.builder()
+                .message("프로필 사진이 수정되었습니다.")
                 .build();
 
         return SuccessResponse.of(message);

--- a/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
@@ -62,10 +62,10 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadCredentialsException("해당 아이디를 갖는 유저가 없습니다."));
 
-        String ImageUrl = profileImage.getOriginalFilename();
+        String imageUrl = profileImage.getOriginalFilename();
 
         if(!profileImage.isEmpty()) {
-            member.updateProfileImage(ImageUrl);
+            member.updateProfileImage(imageUrl);
         }
 
         Message message = Message.builder()

--- a/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/application/MemberService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.member.domain.repository.MemberRepository;
+import samsamoo.ai_mockly.domain.member.dto.response.MemberInfoRes;
+import samsamoo.ai_mockly.domain.point.domain.repository.PointRepository;
 import samsamoo.ai_mockly.global.common.Message;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 
@@ -15,6 +17,23 @@ import samsamoo.ai_mockly.global.common.SuccessResponse;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
+    public SuccessResponse<MemberInfoRes> getMemberInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadCredentialsException("해당 아이디를 갖는 유저가 없습니다."));
+
+        Integer totalPoint = pointRepository.sumActiveAmountByMemberId(memberId);
+
+        MemberInfoRes memberInfoRes = MemberInfoRes.builder()
+                .nickname(member.getNickname())
+                .profileImage(member.getProfileImage())
+                .maxScore(member.getMaxScore())
+                .pointAmount(totalPoint)
+                .build();
+
+        return SuccessResponse.of(memberInfoRes);
+    }
 
     @Transactional
     public SuccessResponse<Message> updateNickname(Long memberId, String nickname) {

--- a/src/main/java/samsamoo/ai_mockly/domain/member/domain/Member.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/domain/Member.java
@@ -40,4 +40,8 @@ public class Member extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberInfoRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberInfoRes.java
@@ -1,0 +1,17 @@
+package samsamoo.ai_mockly.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberInfoRes {
+
+    private String nickname;
+
+    private String profileImage;
+
+    private Integer maxScore;
+
+    private Integer pointAmount;
+}

--- a/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberApi.java
@@ -8,16 +8,31 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import samsamoo.ai_mockly.domain.member.dto.request.UpdateNicknameReq;
+import samsamoo.ai_mockly.domain.member.dto.response.MemberInfoRes;
 import samsamoo.ai_mockly.global.common.Message;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 import samsamoo.ai_mockly.global.exception.ErrorResponse;
 
 @Tag(name = "MemberApi", description = "회원 관련 API입니다.")
 public interface MemberApi {
+
+    @Operation(summary = "회원 정보 불러오기", description = "회원 정보를 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "회원 정보 불러오기 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberInfoRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "회원 정보 불러오기 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @GetMapping("/{memberId}")
+    ResponseEntity<SuccessResponse<MemberInfoRes>> getMemberInfo(
+            @Parameter(description = "정보를 불러오고 싶은 회원 아이디를 입력하시오.", required = true) @PathVariable Long memberId);
 
     @Operation(summary = "닉네임 수정", description = "닉네임을 수정합니다.")
     @ApiResponses(value = {
@@ -32,6 +47,22 @@ public interface MemberApi {
     })
     @PatchMapping("/{memberId}/nickname")
     ResponseEntity<SuccessResponse<Message>> updateNickname(
-            @Parameter(description = "닉네임을 수정하고 싶은 멤버 아이디를 입력하시오.", required = true) @PathVariable Long memberId,
+            @Parameter(description = "닉네임을 수정하고 싶은 회원 아이디를 입력하시오.", required = true) @PathVariable Long memberId,
             @Parameter(description = "Schemas의 UpdateNicknameReq 참고", required = true) @RequestBody UpdateNicknameReq request);
+
+    @Operation(summary = "프로필 사진 수정", description = "프로필 사진을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "프로필 사진 수정 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "프로필 사진 수정 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @PatchMapping("/{memberId}/image")
+    ResponseEntity<SuccessResponse<Message>> modifyProfileImage(
+            @Parameter(description = "프로필 이미지를 수정하고 싶은 회원 아이디를 입력하시오.", required = true) @PathVariable Long memberId,
+            @Parameter(description = "수정할 이미지 파일을 입력하시오.") @RequestPart MultipartFile profileImage);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
@@ -17,6 +17,7 @@ public class MemberController implements MemberApi {
 
     private final MemberService memberService;
 
+    @Override
     @GetMapping("/{memberId}")
     public ResponseEntity<SuccessResponse<MemberInfoRes>> getMemberInfo(@PathVariable Long memberId) {
         return ResponseEntity.ok(memberService.getMemberInfo(memberId));
@@ -28,6 +29,7 @@ public class MemberController implements MemberApi {
         return ResponseEntity.ok(memberService.updateNickname(memberId, request.getNickname()));
     }
 
+    @Override
     @PatchMapping("/{memberId}/image")
     public ResponseEntity<SuccessResponse<Message>> modifyProfileImage(@PathVariable Long memberId, @RequestPart MultipartFile profileImage) {
         return ResponseEntity.ok(memberService.modifyProfileImage(memberId, profileImage));

--- a/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
@@ -3,6 +3,7 @@ package samsamoo.ai_mockly.domain.member.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import samsamoo.ai_mockly.domain.member.application.MemberService;
 import samsamoo.ai_mockly.domain.member.dto.request.UpdateNicknameReq;
 import samsamoo.ai_mockly.domain.member.dto.response.MemberInfoRes;
@@ -25,5 +26,10 @@ public class MemberController implements MemberApi {
     @PatchMapping("/{memberId}/nickname")
     public ResponseEntity<SuccessResponse<Message>> updateNickname(@PathVariable Long memberId, @RequestBody UpdateNicknameReq request) {
         return ResponseEntity.ok(memberService.updateNickname(memberId, request.getNickname()));
+    }
+
+    @PatchMapping("/{memberId}/image")
+    public ResponseEntity<SuccessResponse<Message>> modifyProfileImage(@PathVariable Long memberId, @RequestPart MultipartFile profileImage) {
+        return ResponseEntity.ok(memberService.modifyProfileImage(memberId, profileImage));
     }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/presentation/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import samsamoo.ai_mockly.domain.member.application.MemberService;
 import samsamoo.ai_mockly.domain.member.dto.request.UpdateNicknameReq;
+import samsamoo.ai_mockly.domain.member.dto.response.MemberInfoRes;
 import samsamoo.ai_mockly.global.common.Message;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 
@@ -14,6 +15,11 @@ import samsamoo.ai_mockly.global.common.SuccessResponse;
 public class MemberController implements MemberApi {
 
     private final MemberService memberService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<SuccessResponse<MemberInfoRes>> getMemberInfo(@PathVariable Long memberId) {
+        return ResponseEntity.ok(memberService.getMemberInfo(memberId));
+    }
 
     @Override
     @PatchMapping("/{memberId}/nickname")

--- a/src/main/java/samsamoo/ai_mockly/domain/point/domain/Point.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/point/domain/Point.java
@@ -21,7 +21,7 @@ public class Point extends BaseEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     private Integer amount;

--- a/src/main/java/samsamoo/ai_mockly/domain/point/domain/repository/PointRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/point/domain/repository/PointRepository.java
@@ -1,8 +1,12 @@
 package samsamoo.ai_mockly.domain.point.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import samsamoo.ai_mockly.domain.point.domain.Point;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
+    @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Point p WHERE p.member.id = :memberId AND p.state = 'ACTIVE'")
+    Integer sumActiveAmountByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -25,7 +25,7 @@ CREATE TABLE point
     id         BIGINT AUTO_INCREMENT NOT NULL,
     created_at datetime     NOT NULL,
     updated_at datetime     NOT NULL,
-    member_id  BIGINT       NULL,
+    member_id  BIGINT       NOT NULL,
     amount     INT          NULL,
     type       VARCHAR(255) NULL,
     expired_at datetime     NULL,


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 마이 페이지 정보 api
- [x] 프로필 사진 변경

### 📷 스크린샷

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #8 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 회원 정보 조회 API가 추가되어 닉네임, 프로필 이미지, 최고 점수, 보유 포인트를 확인할 수 있습니다.
  - 회원 프로필 이미지 변경 API가 추가되어 이미지를 수정할 수 있습니다.

- **버그 수정**
  - 포인트 테이블의 member_id가 필수값으로 변경되어 데이터 무결성이 강화되었습니다.

- **기타**
  - OpenAPI 문서화 라이브러리 버전이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->