### PR TITLE
[FEAT]: 회원 로그아웃 및 탈퇴

### DIFF
--- a/src/main/java/samsamoo/ai_mockly/domain/auth/application/AuthService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/application/AuthService.java
@@ -3,6 +3,7 @@ package samsamoo.ai_mockly.domain.auth.application;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
+@Slf4j
 public class AuthService {
 
     @Value("${jwt.refresh.expiration}")
@@ -119,7 +121,7 @@ public class AuthService {
         Instant expiredAt = decodedJWT.getExpiresAt().toInstant();
         Instant now = Instant.now();
         long between = ChronoUnit.SECONDS.between(now, expiredAt);
-        System.out.println("남은 시간 : " + between);
+        log.debug("Access token remaining time: {} seconds", between);
 
         // 남는 시간 만료만큼 AccessToken을 Blacklist에 포함
         redisUtil.setDataExpire(BL_AT_PREFIX + logoutReq.getAccessToken(), "black list token", between);

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/application/AuthService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/application/AuthService.java
@@ -10,6 +10,9 @@ import samsamoo.ai_mockly.domain.auth.dto.response.LoginRes;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.member.domain.repository.MemberRepository;
 import samsamoo.ai_mockly.domain.member.dto.response.MemberDTO;
+import samsamoo.ai_mockly.domain.point.domain.Point;
+import samsamoo.ai_mockly.domain.point.domain.State;
+import samsamoo.ai_mockly.domain.point.domain.repository.PointRepository;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 import samsamoo.ai_mockly.global.security.jwt.JwtTokenProvider;
 import samsamoo.ai_mockly.infrastructure.redis.RedisUtil;
@@ -27,6 +30,8 @@ public class AuthService {
 
     private final KakaoTokenValidator kakaoTokenValidator;
     private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
 
@@ -62,7 +67,15 @@ public class AuthService {
                 .maxScore(0)
                 .build();
 
+        Point point = Point.builder()
+                .member(member)
+                .amount(0)
+                .type("new join")
+                .state(State.ACTIVE)
+                .build();
+
         memberRepository.save(member);
+        pointRepository.save(point);
 
         return member;
     }

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/dto/request/LogoutReq.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/dto/request/LogoutReq.java
@@ -1,0 +1,21 @@
+package samsamoo.ai_mockly.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class LogoutReq {
+
+    @Schema(type = "string",
+            example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInJvbGUiOiJjdnZ6M0BuYXZlci5jb20iLCJpZCI6ImN2dnozQG5hdmVyLmNvbSIsImV4cCI6MTcyMjE4NTU5OSwiZW1haWwiOiJjdnZ6M0BuYXZlci5jb20ifQ.6b3gEhqolM3PcdeDpaT1ExTuNV0_PSQQhGDFEk1IvDnPePbjtV2ZX3ds48_nWx77ci4nSEbS1XsajcV9yW_vBQ",
+            description="access token입니다."
+    )
+    private String accessToken;
+
+    @Schema(
+            type = "string",
+            example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJSZWZyZXNoVG9rZW4iLCJleHAiOjE3MjIxODU2MDl9.hQckv2VUkHeKE2GOIe08xUbvKVwPPV6XoKo0xM5ZgppcIrIHeCCXUSOqhgZtsenMyryYNAgxCFeYDLA30-SfgQ",
+            description="refresh token입니다."
+    )
+    private String refreshToken;
+}

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
@@ -69,8 +69,8 @@ public interface AuthApi {
     })
     @DeleteMapping("/logout")
     ResponseEntity<SuccessResponse<Message>> logout(
-            @Parameter(description = "로그아웃하고 싶은 회원의 Access Token을 입력하시오.", required = true)@LoginMember Member member,
-            @Parameter(description = "Schemas의 LogoutReq를 참고", required = true) @RequestBody LogoutReq logoutReq);
+            @Parameter(description = "로그아웃하고 싶은 회원의 Access Token을 입력하시오.", required = true) @LoginMember Member member,
+            @Parameter(description = "Schemas의 LogoutReq를 참고", required = true) @Valid @RequestBody LogoutReq logoutReq);
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴을 진행합니다.")
     @ApiResponses(value = {

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
@@ -71,4 +71,19 @@ public interface AuthApi {
     ResponseEntity<SuccessResponse<Message>> logout(
             @Parameter(description = "로그아웃하고 싶은 회원의 Access Token을 입력하시오.", required = true)@LoginMember Member member,
             @Parameter(description = "Schemas의 LogoutReq를 참고", required = true) @RequestBody LogoutReq logoutReq);
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴을 진행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "탈퇴 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "탈퇴 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @DeleteMapping("/exit")
+    ResponseEntity<SuccessResponse<Message>> exit(
+            @Parameter(description = "탈퇴하고 싶은 회원의 Access Token을 입력하시오.", required = true) @LoginMember Member member);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthApi.java
@@ -10,13 +10,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import samsamoo.ai_mockly.domain.auth.dto.request.LoginReq;
+import samsamoo.ai_mockly.domain.auth.dto.request.LogoutReq;
 import samsamoo.ai_mockly.domain.auth.dto.response.DuplicateCheckRes;
 import samsamoo.ai_mockly.domain.auth.dto.response.LoginRes;
+import samsamoo.ai_mockly.domain.member.domain.Member;
+import samsamoo.ai_mockly.global.annotation.LoginMember;
+import samsamoo.ai_mockly.global.common.Message;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 import samsamoo.ai_mockly.global.exception.ErrorResponse;
 
@@ -54,4 +55,20 @@ public interface AuthApi {
     ResponseEntity<SuccessResponse<DuplicateCheckRes>> checkNicknameDuplicate(
             @Parameter(description = "검사할 닉네임을 입력해주세요.", required = true) @RequestParam(value = "nickname") String nickname
     );
+
+    @Operation(summary = "회원 로그아웃", description = "회원 로그아웃을 진행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "로그아웃 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "로그아웃 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @DeleteMapping("/logout")
+    ResponseEntity<SuccessResponse<Message>> logout(
+            @Parameter(description = "로그아웃하고 싶은 회원의 Access Token을 입력하시오.", required = true)@LoginMember Member member,
+            @Parameter(description = "Schemas의 LogoutReq를 참고", required = true) @RequestBody LogoutReq logoutReq);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
@@ -6,8 +6,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import samsamoo.ai_mockly.domain.auth.application.AuthService;
 import samsamoo.ai_mockly.domain.auth.dto.request.LoginReq;
+import samsamoo.ai_mockly.domain.auth.dto.request.LogoutReq;
 import samsamoo.ai_mockly.domain.auth.dto.response.DuplicateCheckRes;
 import samsamoo.ai_mockly.domain.auth.dto.response.LoginRes;
+import samsamoo.ai_mockly.domain.member.domain.Member;
+import samsamoo.ai_mockly.global.annotation.LoginMember;
+import samsamoo.ai_mockly.global.common.Message;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 
 @RequiredArgsConstructor
@@ -27,5 +31,12 @@ public class AuthController implements AuthApi {
     @GetMapping("/nicknames")
     public ResponseEntity<SuccessResponse<DuplicateCheckRes>> checkNicknameDuplicate(@RequestParam(value = "nickname") String nickname) {
         return ResponseEntity.ok(authService.checkNicknameDuplicate(nickname));
+    }
+
+    @Override
+    @DeleteMapping("/logout")
+    public ResponseEntity<SuccessResponse<Message>> logout(@LoginMember Member member, @RequestBody LogoutReq logoutReq) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(authService.logout(memberId, logoutReq));
     }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController implements AuthApi {
 
     @Override
     @DeleteMapping("/logout")
-    public ResponseEntity<SuccessResponse<Message>> logout(@LoginMember Member member, @RequestBody LogoutReq logoutReq) {
+    public ResponseEntity<SuccessResponse<Message>> logout(@LoginMember Member member, @Valid @RequestBody LogoutReq logoutReq) {
         Long memberId = member.getId();
         return ResponseEntity.ok(authService.logout(memberId, logoutReq));
     }

--- a/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/auth/presentation/AuthController.java
@@ -39,4 +39,11 @@ public class AuthController implements AuthApi {
         Long memberId = member.getId();
         return ResponseEntity.ok(authService.logout(memberId, logoutReq));
     }
+
+    @Override
+    @DeleteMapping("/exit")
+    public ResponseEntity<SuccessResponse<Message>> exit(@LoginMember Member member) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(authService.exit(memberId));
+    }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
@@ -2,7 +2,11 @@ package samsamoo.ai_mockly.domain.feedback.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import samsamoo.ai_mockly.domain.feedback.domain.Feedback;
+import samsamoo.ai_mockly.domain.member.domain.Member;
+
+import java.util.List;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
+    List<Feedback> findAllByMember(Member member);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberDTO.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberDTO.java
@@ -1,5 +1,6 @@
 package samsamoo.ai_mockly.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,5 +8,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class MemberDTO {
 
+    @Schema(type = "String", example = "${카카오아이디 번호}", description = "카카오 사용자의 아이디 번호입니다.")
     private String kakaoId;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberInfoRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/member/dto/response/MemberInfoRes.java
@@ -1,5 +1,6 @@
 package samsamoo.ai_mockly.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,11 +8,15 @@ import lombok.Data;
 @Builder
 public class MemberInfoRes {
 
+    @Schema(type = "String", example = "닉네임", description = "사용자의 닉네임입니다.")
     private String nickname;
 
+    @Schema(type = "String", example = "profile.png", description = "사용자의 프로필 이미지입니다.")
     private String profileImage;
 
+    @Schema(type = "Integer", example = "15", description = "사용자의 피드백 점수 중 최고점입니다. 최소 0, 최대 15입니다.")
     private Integer maxScore;
 
+    @Schema(type = "Integer", example = "15", description = "사용자의 총 포인트량 입니다.")
     private Integer pointAmount;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/point/domain/repository/PointRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/point/domain/repository/PointRepository.java
@@ -3,10 +3,15 @@ package samsamoo.ai_mockly.domain.point.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.point.domain.Point;
+
+import java.util.List;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
     @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Point p WHERE p.member.id = :memberId AND p.state = 'ACTIVE'")
     Integer sumActiveAmountByMemberId(@Param("memberId") Long memberId);
+
+    List<Point> findAllByMember(Member member);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/domain/repository/ScoreRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/domain/repository/ScoreRepository.java
@@ -1,6 +1,7 @@
 package samsamoo.ai_mockly.domain.score.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.score.domain.Score;
 
 import java.util.List;
@@ -8,4 +9,6 @@ import java.util.List;
 public interface ScoreRepository extends JpaRepository<Score, Long> {
 
     List<Score> findTop5ByHighScoreOrderByTotalScoreDesc(boolean highScore);
+
+    List<Score> findAllByMember(Member member);
 }

--- a/src/main/java/samsamoo/ai_mockly/global/config/SecurityConfig.java
+++ b/src/main/java/samsamoo/ai_mockly/global/config/SecurityConfig.java
@@ -31,13 +31,13 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/auth/**",
             "/members/**",
-            "/scores/**"
+            "/scores/**",
+            "/feedbacks/**"
     };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 회원 로그아웃 API
- [x] 회원 탈퇴 API
- [x] 회원가입 리팩토링

### 📷 스크린샷
![새로운 유저 로그인](https://github.com/user-attachments/assets/e0d0e3f5-47de-4f25-ad4e-6d1f2e141993)
![point 새로 생성(amount=0)](https://github.com/user-attachments/assets/25358154-4fb8-4071-97a9-e0468ea09655)
![로그아웃 성공](https://github.com/user-attachments/assets/c91a9a71-7e7c-48fc-b26a-2432a8c7acf4)
![로그아웃된 유저의 AT 확인](https://github.com/user-attachments/assets/f8fdf334-7316-44bd-af6d-ae0aaf842675)
![스크린샷 2025-05-26 163525](https://github.com/user-attachments/assets/d12ff50a-b7e2-4a88-9f6b-3a7d498c9de2)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #20 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 로그아웃 및 회원 탈퇴(계정 삭제) API가 추가되었습니다. 사용자는 자신의 계정에서 로그아웃하거나 계정을 완전히 삭제할 수 있습니다.
- **버그 수정**
  - 없음
- **문서화**
  - 로그아웃 및 회원 탈퇴 API에 대한 Swagger 문서가 추가되었습니다.
- **기타**
  - 피드백, 포인트, 점수 관련 데이터가 회원 탈퇴 시 함께 삭제됩니다.
  - "/feedbacks/**" 경로가 보안 허용 목록에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->