### PR TITLE
[FEAT] LLM pdf 전송 및 질문 정보 불러오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Flyway
     implementation 'org.flywaydb:flyway-core'

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
@@ -20,6 +20,11 @@ public class LLMService {
 
     private final LLMInterviewClient llmClient;
 
+    private static final String JSON_PARSER_PATTERN = "\\{\\\"status\\\":\\\"success\\\",\\\"question\\\":\\\"(.*?)\\\"\\}";
+    private static final String JSON_SUFFIX_PATTERN = "\\\"}$";
+    private static final String NEWLINE_PATTERN = "\\\\n\\\\n";
+    private static final String QUESTION_SPLIT_PATTERN = "\\d+\\. ";
+
     @Transactional
     public SuccessResponse<LLMResponseDTO> processResumePdf(MultipartFile multipartFile) {
         try {
@@ -40,11 +45,11 @@ public class LLMService {
         }
 
         String cleaned = rawQuestionText
-                .replaceFirst("^\\{\\\"status\\\":\\\"success\\\",\\\"questions\\\":\\\"", "")
-                .replaceAll("\\\\n\\\\n", "")
-                .replaceAll("\\\"}$", "");
+                .replaceFirst(JSON_PARSER_PATTERN, "")
+                .replaceAll(NEWLINE_PATTERN, "")
+                .replaceAll(JSON_SUFFIX_PATTERN, "");
 
-        List<String> questionList = Arrays.stream(cleaned.split("\\d+\\. "))
+        List<String> questionList = Arrays.stream(cleaned.split(QUESTION_SPLIT_PATTERN))
                 .map(String::trim)
                 .filter(question -> !question.isBlank())
                 .collect(Collectors.toList());

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
@@ -1,0 +1,63 @@
+package samsamoo.ai_mockly.domain.llm.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
+import samsamoo.ai_mockly.global.common.SuccessResponse;
+import samsamoo.ai_mockly.infrastructure.external.llm.LLMInterviewClient;
+import samsamoo.ai_mockly.infrastructure.external.llm.dto.LLMResponseDTO;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LLMService {
+
+    private final LLMInterviewClient llmClient;
+
+    @Transactional
+    public SuccessResponse<LLMResponseDTO> processResumePdf(MultipartFile multipartFile) {
+        try {
+            byte[] fileBytes = multipartFile.getBytes();
+            String filename = multipartFile.getOriginalFilename();
+            LLMResponseDTO response = llmClient.uploadPdf(fileBytes, filename).block();
+            return SuccessResponse.of(response);
+        } catch (Exception e) {
+            throw new RuntimeException("파일 처리 중 오류 발생 : " + e.getMessage());
+        }
+    }
+
+    public SuccessResponse<LLMQuestionRes> getGeneratedQuestion() {
+        String rawQuestionText = llmClient.fetchQuestionsText().block();
+
+        if(rawQuestionText == null || rawQuestionText.isBlank()) {
+            throw new IllegalStateException("질문을 가져오는데 실패했습니다.");
+        }
+
+        String cleaned = rawQuestionText
+                .replaceFirst("^\\{\\\"status\\\":\\\"success\\\",\\\"questions\\\":\\\"", "")
+                .replaceAll("\\\\n\\\\n", "")
+                .replaceAll("\\\"}$", "");
+
+        List<String> questionList = Arrays.stream(cleaned.split("\\d+\\. "))
+                .map(String::trim)
+                .filter(question -> !question.isBlank())
+                .collect(Collectors.toList());
+
+        if(questionList.size() < 1) {
+            throw new IllegalStateException("질문 분리에 실패했습니다. 질문 내용을 확인하세요.");
+        }
+
+        LLMQuestionRes llmQuestionRes = LLMQuestionRes.builder()
+                .status("success")
+                .questionList(questionList)
+                .build();
+
+        return SuccessResponse.of(llmQuestionRes);
+    }
+}

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMQuestionRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMQuestionRes.java
@@ -1,0 +1,15 @@
+package samsamoo.ai_mockly.domain.llm.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class LLMQuestionRes {
+
+    private String status;
+
+    private List<String> questionList;
+}

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
@@ -18,6 +18,13 @@ public class LLMController {
 
     @PostMapping("/upload/pdf")
     public ResponseEntity<SuccessResponse<LLMResponseDTO>> uploadPdf(@RequestPart("file") MultipartFile multipartFile) {
+        if(multipartFile==null || multipartFile.isEmpty()) {
+            throw new IllegalArgumentException("파일이 업로드 되지 않음");
+        }
+        String contentType = multipartFile.getContentType();
+        if(contentType == null || !contentType.startsWith("application/pdf")) {
+            throw new IllegalArgumentException("PDF 파일만 업로드 가능합니다.");
+        }
         return ResponseEntity.ok(llmService.processResumePdf(multipartFile));
     }
 

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
@@ -1,0 +1,28 @@
+package samsamoo.ai_mockly.domain.llm.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import samsamoo.ai_mockly.domain.llm.application.LLMService;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
+import samsamoo.ai_mockly.global.common.SuccessResponse;
+import samsamoo.ai_mockly.infrastructure.external.llm.dto.LLMResponseDTO;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/llm")
+public class LLMController {
+
+    private final LLMService llmService;
+
+    @PostMapping("/upload/pdf")
+    public ResponseEntity<SuccessResponse<LLMResponseDTO>> uploadPdf(@RequestPart("file") MultipartFile multipartFile) {
+        return ResponseEntity.ok(llmService.processResumePdf(multipartFile));
+    }
+
+    @GetMapping("/questions")
+    public ResponseEntity<SuccessResponse<LLMQuestionRes>> getGeneratedQuestions() {
+        return ResponseEntity.ok(llmService.getGeneratedQuestion());
+    }
+}

--- a/src/main/java/samsamoo/ai_mockly/global/config/SecurityConfig.java
+++ b/src/main/java/samsamoo/ai_mockly/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
             "/auth/**",
             "/members/**",
             "/scores/**",
-            "/feedbacks/**"
+            "/feedbacks/**",
+            "/llm/**"
     };
 
     @Bean

--- a/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/LLMConfig.java
+++ b/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/LLMConfig.java
@@ -1,0 +1,24 @@
+package samsamoo.ai_mockly.infrastructure.external.llm;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class LLMConfig {
+
+    @Value("${llm.api_key}")
+    private String apiKey;
+
+    @Value("${llm.base_url}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient llmWebClient() {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .build();
+    }
+}

--- a/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/LLMInterviewClient.java
+++ b/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/LLMInterviewClient.java
@@ -1,0 +1,72 @@
+package samsamoo.ai_mockly.infrastructure.external.llm;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import samsamoo.ai_mockly.infrastructure.external.llm.dto.LLMResponseDTO;
+
+import java.io.File;
+
+/**
+ * FastAPI 서버와 통신하여 면접 관련 데이터(PDF, QA)를 업로드하거나 질문/피드백/점수 요청을 수행하는 클라이언트 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class LLMInterviewClient {
+
+    private final WebClient webClient;
+
+    /**
+     * 포트폴리오 PDF 파일을 FastAPI 서버에 업로드하여 질문 생성을 요청합니다.
+     */
+    public Mono<LLMResponseDTO> uploadPdf(byte[] fileBytes, String fileName) {
+        Resource resource = new ByteArrayResource(fileBytes) {
+            @Override
+            public String getFilename() {
+                return fileName;
+            }
+        };
+
+        return webClient.post()
+                .uri("/upload/pdf")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData("file", resource))
+                .retrieve()
+                .bodyToMono(LLMResponseDTO.class);
+    }
+
+    /**
+     * 사용자의 QA 텍스트 파일을 FastAPI 서버에 업로드하여 피드백과 점수를 요청합니다.
+     */
+    public Mono<LLMResponseDTO> uploadQa(byte[] fileBytes, String fileName) {
+        Resource resource = new ByteArrayResource(fileBytes) {
+            @Override
+            public String getFilename() {
+                return fileName;
+            }
+        };
+
+        return webClient.post()
+                .uri("/upload/qa")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData("file", resource))
+                .retrieve()
+                .bodyToMono(LLMResponseDTO.class);
+    }
+
+    /**
+     * 저장된 interview_questions.txt 파일 내용을 FastAPI 서버로부터 가져옵니다.
+     */
+    public Mono<String> fetchQuestionsText() {
+        return webClient.get()
+                .uri("/get-questions-text")
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+}

--- a/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMResponseDTO.java
+++ b/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMResponseDTO.java
@@ -9,7 +9,7 @@ public class LLMResponseDTO {
 
     private String status;  // 요청 처리 상태(ex: success)
     private String message; // 요청 처리 결과 메시지
-    private Object question_status; // 질문 생성 결과
-    private Object feedback_status; // 피드백 생성 결과
-    private Object score_status;    // 점수 산출 결과
+    private Object questionStatus; // 질문 생성 결과
+    private Object feedbackStatus; // 피드백 생성 결과
+    private Object scoreStatus;    // 점수 산출 결과
 }

--- a/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMResponseDTO.java
+++ b/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMResponseDTO.java
@@ -1,0 +1,15 @@
+package samsamoo.ai_mockly.infrastructure.external.llm.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LLMResponseDTO {
+
+    private String status;  // 요청 처리 상태(ex: success)
+    private String message; // 요청 처리 결과 메시지
+    private Object question_status; // 질문 생성 결과
+    private Object feedback_status; // 피드백 생성 결과
+    private Object score_status;    // 점수 산출 결과
+}

--- a/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMScoreResponseDTO.java
+++ b/src/main/java/samsamoo/ai_mockly/infrastructure/external/llm/dto/LLMScoreResponseDTO.java
@@ -1,0 +1,20 @@
+package samsamoo.ai_mockly.infrastructure.external.llm.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LLMScoreResponseDTO {
+
+    private int coreTechUnderstanding;       // 핵심 기술 개념의 이해도
+    private int comparisonAnalysis;          // 비교 및 분석 능력
+    private int performanceOptimization;     // 성능 최적화 고려
+    private int trendAwareness;              // 최신 트렌드 반영
+    private int terminologyAccuracy;         // 기술 용어의 정확성과 일관성
+    private int projectExplanation;          // 프로젝트 기반 설명력
+    private int problemSolvingClarity;       // 문제 해결 과정의 명확성
+    private int resultImprovementEffort;     // 결과 도출 및 개선 노력
+    private int practicalApplicability;      // 실무 적용 가능성
+    private int collaborationContribution;   // 협업 및 기여도 표현
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   profiles:
     active: ["db", "jwt", "infra"]
+
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] LLM FastAPI와 연동
- [x] pdf 파일 전송
- [x] 질문 내용 불러오기

### 📷 스크린샷
![image](https://github.com/user-attachments/assets/c19e15cc-c679-4137-81f7-69637205ab6e)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #28 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - PDF 이력서 파일 업로드 및 처리 기능이 추가되었습니다.
  - 업로드된 이력서를 기반으로 면접 질문을 자동 생성하여 조회할 수 있는 기능이 제공됩니다.
- **API 변경**
  - `/llm/upload/pdf` 엔드포인트에서 PDF 파일 업로드 지원
  - `/llm/questions` 엔드포인트에서 자동 생성된 면접 질문 목록 조회 가능
- **설정**
  - 파일 업로드 최대 크기가 5MB로 제한되었습니다.
  - 관련 API 접근 시 인증 없이 이용할 수 있도록 보안 설정이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->