### PR TITLE
[REFACTOR]: 랭킹 목록 조회 시 피드백 및 해제 여부

### DIFF
--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
@@ -11,5 +11,5 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByMember(Member member);
 
-    Optional<Feedback> findByMember(Member member);
+    Optional<Feedback> findTopByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/presentation/FeedbackApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/presentation/FeedbackApi.java
@@ -23,7 +23,7 @@ import samsamoo.ai_mockly.global.exception.ErrorResponse;
 
 import java.util.List;
 
-@Tag(name = "FeedbackAPI", description = "면접 피드백 및 결과 리포트 관련 API입니다.")
+@Tag(name = "Feedback API", description = "면접 피드백 및 결과 리포트 관련 API입니다.")
 public interface FeedbackApi {
 
     @Operation(summary = "피드백 내용 저장", description = "회원의 피드백 내용을 저장합니다.")
@@ -72,4 +72,20 @@ public interface FeedbackApi {
     ResponseEntity<SuccessResponse<FeedbackContentsRes>> getFeedbackContent(
             @Parameter(description = "정보를 불러오고 싶은 회원의 Access Token을 입력하시오.", required = true) @LoginMember Member member,
             @Parameter(description = "불러올 피드백의 id를 입력하시오.", required = true) @PathVariable Long feedbackId);
+
+    @Operation(summary = "피드백 잠금 해제", description = "선택한 피드백을 해제합니다. 해제한 피드백은 계속 볼 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "피드백 잠금 해제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "피드백 잠금 해제 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @PostMapping("/contents/{feedbackId}/unlock")
+    ResponseEntity<SuccessResponse<Message>> unlockFeedback(
+            @Parameter(description = "해제할 회원의 Access Token을 입력하시오.", required = true) @LoginMember Member member,
+            @Parameter(description = "해제할 피드백의 id를 입력하시오.", required = true) @PathVariable Long feedbackId);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/presentation/FeedbackController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/presentation/FeedbackController.java
@@ -42,6 +42,7 @@ public class FeedbackController implements FeedbackApi {
         return ResponseEntity.ok(feedbackService.getFeedbackContent(memberId, feedbackId));
     }
 
+    @Override
     @PostMapping("/contents/{feedbackId}/unlock")
     public ResponseEntity<SuccessResponse<Message>> unlockFeedback(@LoginMember Member member, @PathVariable Long feedbackId) {
         Long memberId = member.getId();

--- a/src/main/java/samsamoo/ai_mockly/domain/point/presentation/PointApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/point/presentation/PointApi.java
@@ -1,0 +1,71 @@
+package samsamoo.ai_mockly.domain.point.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import samsamoo.ai_mockly.domain.member.domain.Member;
+import samsamoo.ai_mockly.domain.point.dto.request.PointAmountReq;
+import samsamoo.ai_mockly.global.annotation.LoginMember;
+import samsamoo.ai_mockly.global.common.Message;
+import samsamoo.ai_mockly.global.common.SuccessResponse;
+import samsamoo.ai_mockly.global.exception.ErrorResponse;
+
+@Tag(name = "Point API", description = "포인트 관련 API입니다.")
+public interface PointApi {
+
+    @Operation(summary = "포인트 잔고 확인", description = "회원의 포인트 잔고를 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "회원 포인트 잔고 불러오기 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "회원 포인트 잔고 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @GetMapping("/me")
+    ResponseEntity<SuccessResponse<Integer>> getCurrentAmount(
+            @Parameter(description = "정보를 불러오고 싶은 회원의 Access Token을 입력하시오.", required = true) @LoginMember Member member);
+
+    @Operation(summary = "포인트 증가", description = "포인트를 증가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "포인트 증가 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "포인트 증가 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @PostMapping("/add")
+    ResponseEntity<SuccessResponse<Message>> addPoint(
+            @Parameter(description = "포인트를 더할 회원의 Access Token을 입력하시오.", required = true)@LoginMember Member member,
+            @Parameter(description = "포인트 증감 Request", required = true) @Valid @RequestBody PointAmountReq pointAmountReq);
+
+    @Operation(summary = "포인트 차감", description = "포인트를 차감합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "포인트 차감 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "포인트 차감 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @PostMapping("/deduct")
+    ResponseEntity<SuccessResponse<Message>> deductPoint(
+            @Parameter(description = "포인트를 뺄 회원의 Access Token을 입력하시오.", required = true)@LoginMember Member member,
+            @Parameter(description = "포인트 증감 Request", required = true) @Valid @RequestBody PointAmountReq pointAmountReq);
+}

--- a/src/main/java/samsamoo/ai_mockly/domain/point/presentation/PointController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/point/presentation/PointController.java
@@ -14,16 +14,18 @@ import samsamoo.ai_mockly.global.common.SuccessResponse;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/points")
-public class PointController {
+public class PointController implements PointApi {
 
     private final PointService pointService;
 
+    @Override
     @GetMapping("/me")
     public ResponseEntity<SuccessResponse<Integer>> getCurrentAmount(@LoginMember Member member) {
         Long memberId = member.getId();
         return ResponseEntity.ok(pointService.getCurrentAmount(memberId));
     }
 
+    @Override
     @PostMapping("/add")
     public ResponseEntity<SuccessResponse<Message>> addPoint(@LoginMember Member member, @Valid @RequestBody PointAmountReq pointAmountReq) {
         Long memberId = member.getId();
@@ -32,11 +34,12 @@ public class PointController {
         return ResponseEntity.ok(pointService.addPoint(memberId, amount, reason));
     }
 
+    @Override
     @PostMapping("/deduct")
-    public ResponseEntity<SuccessResponse<Message>> deductPoint(@LoginMember Member member, @Valid @RequestBody PointAmountReq pointAmountReqt) {
+    public ResponseEntity<SuccessResponse<Message>> deductPoint(@LoginMember Member member, @Valid @RequestBody PointAmountReq pointAmountReq) {
         Long memberId = member.getId();
-        Integer amount = pointAmountReqt.getPointAmount();
-        String reason = pointAmountReqt.getReason();
+        Integer amount = pointAmountReq.getPointAmount();
+        String reason = pointAmountReq.getReason();
         return ResponseEntity.ok(pointService.deductPoint(memberId, amount, reason));
     }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/application/ScoreService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/application/ScoreService.java
@@ -7,6 +7,7 @@ import samsamoo.ai_mockly.domain.feedback.domain.Feedback;
 import samsamoo.ai_mockly.domain.feedback.domain.repository.FeedbackRepository;
 import samsamoo.ai_mockly.domain.feedbackaccess.repository.FeedbackAccessRepository;
 import samsamoo.ai_mockly.domain.member.domain.Member;
+import samsamoo.ai_mockly.domain.member.domain.repository.MemberRepository;
 import samsamoo.ai_mockly.domain.score.domain.Score;
 import samsamoo.ai_mockly.domain.score.domain.repository.ScoreRepository;
 import samsamoo.ai_mockly.domain.score.dto.response.RankingListRes;
@@ -23,8 +24,12 @@ public class ScoreService {
     private final ScoreRepository scoreRepository;
     private final FeedbackRepository feedbackRepository;
     private final FeedbackAccessRepository feedbackAccessRepository;
+    private final MemberRepository memberRepository;
 
     public SuccessResponse<List<RankingListRes>> getRankingList(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디를 갖는 유저가 없습니다."));
+
         List<Score> scoreList = scoreRepository.findTop5ByHighScoreOrderByTotalScoreDesc(true);
 
         List<RankingListRes> rankingList = scoreList.stream()
@@ -34,8 +39,8 @@ public class ScoreService {
                             .orElse(null);
                     Boolean unlocked = false;
 
-                    if(memberId != null) {
-                        unlocked = feedback.getMember().equals(scoreMember) || feedbackAccessRepository.existsByViewerAndFeedback(scoreMember, feedback);
+                    if(memberId != null && feedback != null) {
+                        unlocked = feedback.getMember().equals(member) || feedbackAccessRepository.existsByViewerAndFeedback(member, feedback);
                     }
 
                     return RankingListRes.builder()

--- a/src/main/java/samsamoo/ai_mockly/domain/score/dto/response/RankingListRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/dto/response/RankingListRes.java
@@ -16,4 +16,10 @@ public class RankingListRes {
 
     @Schema(type = "Double", example = "100.0", description = "멤버의 총 점수를 출력합니다.")
     private Double score;
+
+    @Schema(type = "String", example = "멤버의 **피드백 내용**입니다.", description = "멤버의 피드백 내용을 출력합니다.")
+    private String feedback;
+
+    @Schema(type = "Boolean", example = "true", description = "피드백의 잠금 해제 여부를 출력합니다. true면 해제된 상태입니다.")
+    private Boolean unlocked;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreApi.java
@@ -1,6 +1,7 @@
 package samsamoo.ai_mockly.domain.score.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,11 +9,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.score.dto.response.RankingListRes;
+import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 import samsamoo.ai_mockly.global.exception.ErrorResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 @Tag(name = "Score API", description = "점수 관련 API")
 public interface ScoreApi {
@@ -29,5 +33,6 @@ public interface ScoreApi {
             )
     })
     @GetMapping("/rank")
-    ResponseEntity<SuccessResponse<List<RankingListRes>>> getRankingList();
+    ResponseEntity<SuccessResponse<List<RankingListRes>>> getRankingList(
+            @Parameter(description = "랭킹 조회 시 AccessToken이 필요한 경우 사용합니다.") @LoginMember Optional<Member> memberOpt);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreApi.java
@@ -25,7 +25,7 @@ public interface ScoreApi {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "랭킹 리스트 조회 성공",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = SuccessResponse.class))}
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = RankingListRes.class))}
             ),
             @ApiResponse(
                     responseCode = "400", description = "랭킹 리스트 조회 실패(잘못된 요청 방식)",

--- a/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/presentation/ScoreController.java
@@ -5,11 +5,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.domain.score.application.ScoreService;
 import samsamoo.ai_mockly.domain.score.dto.response.RankingListRes;
+import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.SuccessResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,8 +21,10 @@ public class ScoreController implements ScoreApi {
 
     private final ScoreService scoreService;
 
+    @Override
     @GetMapping("/rank")
-    public ResponseEntity<SuccessResponse<List<RankingListRes>>> getRankingList() {
-        return ResponseEntity.ok(scoreService.getRankingList());
+    public ResponseEntity<SuccessResponse<List<RankingListRes>>> getRankingList(@LoginMember Optional<Member> memberOpt) {
+        Long memberId = memberOpt.map(Member::getId).orElse(null);
+        return ResponseEntity.ok(scoreService.getRankingList(memberId));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 랭킹 목록 응답값에 피드백, 해제 여부 반환
- [x] swagger 적용

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #39 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 포인트 관리 기능이 추가되어, 사용자는 자신의 포인트 잔액 조회, 포인트 충전 및 차감이 가능합니다.
  - 피드백 잠금 해제 API가 추가되어, 선택한 피드백을 잠금 해제할 수 있습니다.

- **기능 개선**
  - 랭킹 리스트에 각 회원의 최신 피드백 내용과 잠금 해제 여부가 표시됩니다.
  - 랭킹 조회 시 로그인 여부에 따라 피드백 잠금 해제 상태가 반영됩니다.
  - 피드백 조회 시 가장 최근 생성된 피드백을 우선적으로 반환하도록 개선되었습니다.

- **문서화**
  - API 문서의 태그 및 응답 예시가 보다 명확하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->