### PR TITLE
[REFACTOR]: 점수 계산 로직 및 랭킹 리스트 응답값 수정

### DIFF
--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import samsamoo.ai_mockly.domain.feedback.domain.Feedback;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,5 +12,5 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByMember(Member member);
 
-    Optional<Feedback> findTopByMemberOrderByCreatedAtDesc(Member member);
+    Optional<Feedback> findByMemberAndCreatedAt(Member member, LocalDateTime createdAt);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/application/LLMService.java
@@ -236,7 +236,6 @@ public class LLMService {
                 .replaceAll(JSON_SUFFIX_PATTERN, "");
 
         Map<String, Integer> scoreMap = new LinkedHashMap<>();
-        AtomicInteger totalScore = new AtomicInteger(0);
 
         Arrays.stream(cleaned.split("\\/100"))
                 .map(String::trim)
@@ -246,7 +245,6 @@ public class LLMService {
                     String label = pair[0].trim();
                     Integer value = Integer.parseInt(pair[1].trim());
                     scoreMap.put(label, value);
-                    totalScore.addAndGet(value);
                 });
 
         return scoreMap;

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMFeedbackRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMFeedbackRes.java
@@ -1,5 +1,6 @@
 package samsamoo.ai_mockly.domain.llm.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,5 +10,6 @@ import java.util.List;
 @Builder
 public class LLMFeedbackRes {
 
+    @Schema(type = "List<String>", example = "[**첫번째 피드백**, **두번째 피드백**]", description = "피드백을 각 카테고리에 맞춰 리스트 형태로 출력합니다")
     private List<String> feedbackList;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMScoreRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMScoreRes.java
@@ -10,4 +10,8 @@ import java.util.Map;
 public class LLMScoreRes {
 
     private Map<String, Integer> scoreMap;
+
+    private double techScore;
+    private double communicateScore;
+    private double totalScore;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMScoreRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/dto/response/LLMScoreRes.java
@@ -1,5 +1,6 @@
 package samsamoo.ai_mockly.domain.llm.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,9 +10,17 @@ import java.util.Map;
 @Builder
 public class LLMScoreRes {
 
+    @Schema(type = "HashMap",
+            example = "{**카테고리명** : **점수**, **카테고리명** : **점수**}",
+            description = "면접 점수 세부정보를 출력합니다.")
     private Map<String, Integer> scoreMap;
 
+    @Schema(type = "Double", example = "85.35", description = "첫번째 묶음인 기술 전문성 및 문제 해결 능력 카테고리의 점수입니다.")
     private double techScore;
+
+    @Schema(type = "Double", example = "52.12", description = "두번째 묶음인 표현력 및 커뮤니케이션 역량 카테고리의 점수입니다.")
     private double communicateScore;
+
+    @Schema(type = "Double", example = "75.38", description = "두 개의 카테고리를 조화 평균으로 계산한 총 점수입니다.")
     private double totalScore;
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMApi.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMFeedbackRes;
 import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMScoreRes;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.Message;
@@ -70,34 +72,31 @@ public interface LLMApi {
             @Parameter(description = "LLM 결과를 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> member,
             @Parameter(description = "LLM에 보낼 txt 파일을 입력하세요. key 값은 STT_file입니다.", required = true) @RequestPart("STT_file") MultipartFile multipartFile);
 
-//    @Operation(summary = "면접 피드백 불러오기", description = "LLM에 받은 면접 피드백을 불러옵니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(
-//                    responseCode = "200", description = "면접 피드백 불러오기 성공",
-//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMFeedbackRes.class))}
-//            ),
-//            @ApiResponse(
-//                    responseCode = "400", description = "면접 피드백 불러오기 실패(잘못된 요청 방식)",
-//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
-//            )
-//    })
-//    @GetMapping("/feedbacks")
-//    ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(
-//            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt);
-//
-//    @Operation(summary = "면접 점수 불러오기", description = "LLM에 받은 면접 점수를 불러옵니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(
-//                    responseCode = "200", description = "면접 점수 불러오기 성공",
-//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMScoreRes.class))}
-//            ),
-//            @ApiResponse(
-//                    responseCode = "400", description = "면접 점수 불러오기 실패(잘못된 요청 방식)",
-//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
-//            )
-//    })
-//    @GetMapping("/scores")
-//    ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(
-//            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt
-//    );
+    @Operation(summary = "면접 피드백 불러오기", description = "LLM에 받은 면접 피드백을 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "면접 피드백 불러오기 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMFeedbackRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "면접 피드백 불러오기 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @GetMapping("/feedbacks")
+    ResponseEntity<SuccessResponse<LLMFeedbackRes>> getFeedbackResult();
+
+    @Operation(summary = "면접 점수 불러오기", description = "LLM에 받은 면접 점수를 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "면접 점수 불러오기 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMScoreRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "면접 점수 불러오기 실패(잘못된 요청 방식)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    @GetMapping("/scores")
+    ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreResult();
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMApi.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMApi.java
@@ -13,9 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import samsamoo.ai_mockly.domain.llm.dto.response.LLMFeedbackRes;
 import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
-import samsamoo.ai_mockly.domain.llm.dto.response.LLMScoreRes;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.Message;
@@ -69,36 +67,37 @@ public interface LLMApi {
     })
     @PostMapping(value = "/upload/qa", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<SuccessResponse<Message>> uploadQa(
+            @Parameter(description = "LLM 결과를 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> member,
             @Parameter(description = "LLM에 보낼 txt 파일을 입력하세요. key 값은 STT_file입니다.", required = true) @RequestPart("STT_file") MultipartFile multipartFile);
 
-    @Operation(summary = "면접 피드백 불러오기", description = "LLM에 받은 면접 피드백을 불러옵니다.")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200", description = "면접 피드백 불러오기 성공",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMFeedbackRes.class))}
-            ),
-            @ApiResponse(
-                    responseCode = "400", description = "면접 피드백 불러오기 실패(잘못된 요청 방식)",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
-            )
-    })
-    @GetMapping("/feedbacks")
-    ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(
-            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt);
-
-    @Operation(summary = "면접 점수 불러오기", description = "LLM에 받은 면접 점수를 불러옵니다.")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200", description = "면접 점수 불러오기 성공",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMScoreRes.class))}
-            ),
-            @ApiResponse(
-                    responseCode = "400", description = "면접 점수 불러오기 실패(잘못된 요청 방식)",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
-            )
-    })
-    @GetMapping("/scores")
-    ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(
-            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt
-    );
+//    @Operation(summary = "면접 피드백 불러오기", description = "LLM에 받은 면접 피드백을 불러옵니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(
+//                    responseCode = "200", description = "면접 피드백 불러오기 성공",
+//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMFeedbackRes.class))}
+//            ),
+//            @ApiResponse(
+//                    responseCode = "400", description = "면접 피드백 불러오기 실패(잘못된 요청 방식)",
+//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+//            )
+//    })
+//    @GetMapping("/feedbacks")
+//    ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(
+//            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt);
+//
+//    @Operation(summary = "면접 점수 불러오기", description = "LLM에 받은 면접 점수를 불러옵니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(
+//                    responseCode = "200", description = "면접 점수 불러오기 성공",
+//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LLMScoreRes.class))}
+//            ),
+//            @ApiResponse(
+//                    responseCode = "400", description = "면접 점수 불러오기 실패(잘못된 요청 방식)",
+//                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+//            )
+//    })
+//    @GetMapping("/scores")
+//    ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(
+//            @Parameter(description = "피드백에 저장할 멤버의 AccessToken을 입력하세요. null은 게스트입니다.") @LoginMember Optional<Member> memberOpt
+//    );
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
@@ -6,9 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import samsamoo.ai_mockly.domain.llm.application.LLMService;
-import samsamoo.ai_mockly.domain.llm.dto.response.LLMFeedbackRes;
 import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
-import samsamoo.ai_mockly.domain.llm.dto.response.LLMScoreRes;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.Message;
@@ -44,7 +42,8 @@ public class LLMController implements LLMApi {
 
     @Override
     @PostMapping(value = "/upload/qa", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponse<Message>> uploadQa(@RequestPart("STT_file") MultipartFile multipartFile) {
+    public ResponseEntity<SuccessResponse<Message>> uploadQa(@LoginMember Optional<Member> memberOpt, @RequestPart("STT_file") MultipartFile multipartFile) {
+        Long memberId = memberOpt.map(Member::getId).orElse(null);
         if(multipartFile==null || multipartFile.isEmpty()) {
             throw new IllegalArgumentException("파일이 업로드 되지 않음");
         }
@@ -52,20 +51,20 @@ public class LLMController implements LLMApi {
         if(contentType == null || !contentType.startsWith("text/plain")) {
             throw new IllegalArgumentException("txt 파일만 업로드 가능합니다.");
         }
-        return ResponseEntity.ok(llmService.processResumeQa(multipartFile));
+        return ResponseEntity.ok(llmService.processResumeQa(multipartFile, memberId));
     }
 
-    @Override
-    @GetMapping("/feedbacks")
-    public ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(@LoginMember Optional<Member> memberOpt) {
-        Long memberId = memberOpt.map(Member::getId).orElse(null);
-        return ResponseEntity.ok(llmService.getEvaluateFeedback(memberId));
-    }
-
-    @Override
-    @GetMapping("/scores")
-    public ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(@LoginMember Optional<Member> memberOpt) {
-        Long memberId = memberOpt.map(Member::getId).orElse(null);
-        return ResponseEntity.ok(llmService.getScoreFeedback(memberId));
-    }
+//    @Override
+//    @GetMapping("/feedbacks")
+//    public ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(@LoginMember Optional<Member> memberOpt) {
+//        Long memberId = memberOpt.map(Member::getId).orElse(null);
+//        return ResponseEntity.ok(llmService.getEvaluateFeedback(memberId));
+//    }
+//
+//    @Override
+//    @GetMapping("/scores")
+//    public ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(@LoginMember Optional<Member> memberOpt) {
+//        Long memberId = memberOpt.map(Member::getId).orElse(null);
+//        return ResponseEntity.ok(llmService.getScoreFeedback(memberId));
+//    }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/llm/presentation/LLMController.java
@@ -6,7 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import samsamoo.ai_mockly.domain.llm.application.LLMService;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMFeedbackRes;
 import samsamoo.ai_mockly.domain.llm.dto.response.LLMQuestionRes;
+import samsamoo.ai_mockly.domain.llm.dto.response.LLMScoreRes;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 import samsamoo.ai_mockly.global.annotation.LoginMember;
 import samsamoo.ai_mockly.global.common.Message;
@@ -54,17 +56,15 @@ public class LLMController implements LLMApi {
         return ResponseEntity.ok(llmService.processResumeQa(multipartFile, memberId));
     }
 
-//    @Override
-//    @GetMapping("/feedbacks")
-//    public ResponseEntity<SuccessResponse<LLMFeedbackRes>> getEvaluateFeedback(@LoginMember Optional<Member> memberOpt) {
-//        Long memberId = memberOpt.map(Member::getId).orElse(null);
-//        return ResponseEntity.ok(llmService.getEvaluateFeedback(memberId));
-//    }
-//
-//    @Override
-//    @GetMapping("/scores")
-//    public ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreFeedback(@LoginMember Optional<Member> memberOpt) {
-//        Long memberId = memberOpt.map(Member::getId).orElse(null);
-//        return ResponseEntity.ok(llmService.getScoreFeedback(memberId));
-//    }
+    @Override
+    @GetMapping("/feedbacks")
+    public ResponseEntity<SuccessResponse<LLMFeedbackRes>> getFeedbackResult() {
+        return ResponseEntity.ok(llmService.getFeedbackResult());
+    }
+
+    @Override
+    @GetMapping("/scores")
+    public ResponseEntity<SuccessResponse<LLMScoreRes>> getScoreResult() {
+        return ResponseEntity.ok(llmService.getScoreResult());
+    }
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/dto/response/RankingListRes.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/dto/response/RankingListRes.java
@@ -14,8 +14,14 @@ public class RankingListRes {
     @Schema(type = "String", example = "닉네임", description = "멤버의 닉네임을 출력합니다.")
     private String nickname;
 
-    @Schema(type = "Double", example = "100.0", description = "멤버의 총 점수를 출력합니다.")
-    private Double score;
+    @Schema(type = "Double", example = "85.35", description = "첫번째 묶음인 기술 전문성 및 문제 해결 능력 카테고리의 점수입니다.")
+    private double techScore;
+
+    @Schema(type = "Double", example = "52.12", description = "두번째 묶음인 표현력 및 커뮤니케이션 역량 카테고리의 점수입니다.")
+    private double communicateScore;
+
+    @Schema(type = "Double", example = "75.38", description = "두 개의 카테고리를 조화 평균으로 계산한 총 점수입니다.")
+    private double totalScore;
 
     @Schema(type = "String", example = "멤버의 **피드백 내용**입니다.", description = "멤버의 피드백 내용을 출력합니다.")
     private String feedback;

--- a/src/main/java/samsamoo/ai_mockly/domain/scoredetails/domain/Category.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/scoredetails/domain/Category.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,4 +37,22 @@ public enum Category {
         }
         return category;
     }
+
+    // 기술 전문성 및 문제 해결 능력 카테고리
+    public static final Set<Category> TECHNICAL_AND_PROBLEM_SOLVING_CATEGORY = Set.of(
+            CORE_TECH_UNDERSTANDING,
+            COMPARISON_ANALYSIS,
+            PERFORMANCE_OPTIMIZATION,
+            TREND_AWARENESS,
+            PROBLEM_SOLVING_CLARITY
+    );
+
+    // 표현력 및 커뮤니케이션 역량 카테고리
+    public static final Set<Category> COMMUNICATION_AND_EXPRESSION_CATEGORY = Set.of(
+            TERMINOLOGY_ACCURACY,
+            PROJECT_EXPLANATION,
+            RESULT_IMPROVEMENT_EFFORT,
+            PRACTICAL_APPLICABILITY,
+            COLLABORATION_CONTRIBUTION
+    );
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 점수 계산 로직 수정
- [x] QA 시 DB 저장 로직 수정
- [x] LLM에서 feedback과 score GET하는 로직 수정
- [x] RankingList의 Response값 수정

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #54 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 기술 점수, 커뮤니케이션 점수, 총점(조화평균) 등 세부 점수 항목이 도입되어 랭킹 및 결과 화면에서 각 영역별 점수를 확인할 수 있습니다.
  - 피드백 및 점수 결과를 별도 API로 조회할 수 있습니다.
  - 이력서 QA 업로드 시 로그인 멤버 정보를 선택적으로 전달할 수 있습니다.

- **Improvements**
  - 점수 산정 방식이 기존 평균에서 조화평균(Harmonic Mean) 기반으로 변경되어, 기술 및 커뮤니케이션 역량이 균형 있게 반영됩니다.
  - 랭킹 리스트에서 피드백 조회 기준이 최신 피드백에서 생성 시점 기준으로 변경되었습니다.
  - API 명칭 및 파라미터가 보다 명확하게 개선되었습니다.

- **Documentation**
  - API 응답 예시 및 설명이 Swagger 문서에 추가되어, 각 점수 항목과 피드백 리스트의 의미를 쉽게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->