### PR TITLE
[REFACTOR] rankingList 중 feedback 조회 범위 수정

### DIFF
--- a/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/feedback/domain/repository/FeedbackRepository.java
@@ -1,6 +1,8 @@
 package samsamoo.ai_mockly.domain.feedback.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import samsamoo.ai_mockly.domain.feedback.domain.Feedback;
 import samsamoo.ai_mockly.domain.member.domain.Member;
 
@@ -12,5 +14,9 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByMember(Member member);
 
-    Optional<Feedback> findByMemberAndCreatedAt(Member member, LocalDateTime createdAt);
+    @Query("SELECT f FROM Feedback f WHERE f.member = :member AND f.createdAt BETWEEN :startTime AND :endTime " +
+            "ORDER BY f.createdAt DESC LIMIT 1")
+    Optional<Feedback> findByMemberAndCreatedAtBetweenOrderByCreatedAtDesc(@Param("member") Member member,
+                                                                           @Param("startTime") LocalDateTime startTime,
+                                                                           @Param("endTime") LocalDateTime endTime);
 }

--- a/src/main/java/samsamoo/ai_mockly/domain/score/application/ScoreService.java
+++ b/src/main/java/samsamoo/ai_mockly/domain/score/application/ScoreService.java
@@ -17,8 +17,8 @@ import samsamoo.ai_mockly.global.common.SuccessResponse;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -38,7 +38,11 @@ public class ScoreService {
                 .map(score -> {
                     Member scoreMember = score.getMember();
 
-                    Feedback feedback = feedbackRepository.findByMemberAndCreatedAt(scoreMember, score.getCreatedAt())
+                    LocalDateTime scoreTime = score.getCreatedAt();
+                    LocalDateTime startTime = scoreTime.minusSeconds(1);
+                    LocalDateTime endTime = scoreTime.plusSeconds(1);
+
+                    Feedback feedback = feedbackRepository.findByMemberAndCreatedAtBetweenOrderByCreatedAtDesc(scoreMember, startTime, endTime)
                             .orElse(null);
 
                     Boolean unlocked = false;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] rankingList 중 feedback 조회 범위 수정

### 📷 스크린샷
![image](https://github.com/user-attachments/assets/4f5153ee-cc40-40cd-85d0-1d74c8b6d888)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #57 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 점수와 피드백 연결 시, 피드백 생성 시각이 정확히 일치하지 않아도 1초 이내의 피드백을 정상적으로 조회할 수 있도록 개선되었습니다.  
- **기능 개선**
  - 점수 랭킹 목록에서 더 유연하게 피드백이 연결되어, 일부 누락되던 피드백이 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->